### PR TITLE
Fix missing color in PaletteChunk

### DIFF
--- a/src/ase/chunks/PaletteChunk.hx
+++ b/src/ase/chunks/PaletteChunk.hx
@@ -50,7 +50,7 @@ class PaletteChunk extends Chunk {
 
     var entryStart:Int = 20;
 
-    for (entryNum in firstColorIndex...lastColorIndex) {
+    for (entryNum in firstColorIndex...lastColorIndex + 1) {
       var entry:PaletteEntry = new PaletteEntry(bytesInput.read(PaletteEntry.SIZE));
       entries.set(entryNum, entry);
       entryStart += PaletteEntry.SIZE;


### PR DESCRIPTION
Hi! I've been working on a renderer for Heaps using this library, and noticed that PaletteChunk wasn't parsing the last color in any of my Aseprite files. You can see the discrepancy here:

My Aseprite file (using the Indexed Color Mode):
<img width="828" alt="Screen Shot 2020-10-17 at 12 40 55 PM" src="https://user-images.githubusercontent.com/9554269/96348368-484b1e80-1076-11eb-9ee8-fc604a480c66.png">

My renderer:
<img width="552" alt="Screen Shot 2020-10-17 at 12 41 47 PM" src="https://user-images.githubusercontent.com/9554269/96348420-8c3e2380-1076-11eb-968a-64d553f88425.png">

Thankfully its a quick fix - just needed to increase the length of the loop where Palette entries are parsed by 1 and then the renderer was able to get the last color just fine:

<img width="531" alt="Screen Shot 2020-10-17 at 12 42 15 PM" src="https://user-images.githubusercontent.com/9554269/96348473-01a9f400-1077-11eb-838c-7760430a77df.png">

PS - Thanks for your work on this! It enabled me to get my own Heaps renderer ([heaps-aseprite](https://github.com/AustinEast/heaps-aseprite)) up in running in only a couple of days 😁 
