### PR TITLE
Fixed null palette (made optional in 1.3.5)

### DIFF
--- a/src/ase/Ase.hx
+++ b/src/ase/Ase.hx
@@ -112,7 +112,8 @@ using Lambda;
       ase.frames.push(frame);
     }
 
-    final paletteChunk:PaletteChunk = cast ase.firstFrame.chunkTypes[ChunkType.PALETTE][0];
+    var untypedChunks = ase.frames[0].chunkTypes[ChunkType.PALETTE];
+    final paletteChunk:PaletteChunk = untypedChunks!=null && untypedChunks.length>0 ? (cast untypedChunks)[0] : null;
 
     ase.palette = new Palette(paletteChunk);
 


### PR DESCRIPTION
This commit fixes the now optional palette chunk, see official format change: https://github.com/aseprite/aseprite/commit/10dda30a15a58d09e561a59594f348b4db3a4405 
